### PR TITLE
Add an AttributeMap and MultiTriangleCollection

### DIFF
--- a/src/geoflow/common.cpp
+++ b/src/geoflow/common.cpp
@@ -352,6 +352,10 @@ bool MultiTriangleCollection::has_attributes()
 {
   return !attributes_.empty();
 }
+bool MultiTriangleCollection::has_attributes() const
+{
+  return !attributes_.empty();
+}
 
 std::vector<TriangleCollection>& MultiTriangleCollection::get_tricollections()
 {

--- a/src/geoflow/common.cpp
+++ b/src/geoflow/common.cpp
@@ -328,4 +328,65 @@ const std::vector<int>& Mesh::get_labels() const {
 //   return attributes_;
 // };
 
+void MultiTriangleCollection::push_back(
+  TriangleCollection& trianglecollection)
+{
+  trianglecollections_.push_back(trianglecollection);
+}
+void MultiTriangleCollection::push_back(
+  AttributeMap& attributemap)
+{
+  attributes_.push_back(attributemap);
+}
+
+size_t MultiTriangleCollection::tri_size() const
+{
+  return trianglecollections_.size();
+}
+size_t MultiTriangleCollection::attr_size() const
+{
+  return attributes_.size();
+}
+
+bool MultiTriangleCollection::has_attributes()
+{
+  return !attributes_.empty();
+}
+
+std::vector<TriangleCollection>& MultiTriangleCollection::get_tricollections()
+{
+  return trianglecollections_;
+}
+const std::vector<TriangleCollection>& MultiTriangleCollection::get_tricollections() const
+{
+  return trianglecollections_;
+}
+
+std::vector<AttributeMap>& MultiTriangleCollection::get_attributes()
+{
+  return attributes_;
+}
+const std::vector<AttributeMap>& MultiTriangleCollection::get_attributes() const
+{
+  return attributes_;
+}
+
+TriangleCollection& MultiTriangleCollection::tri_at(size_t i)
+{
+  return trianglecollections_.at(i);
+}
+const TriangleCollection& MultiTriangleCollection::tri_at(size_t i) const
+{
+  return trianglecollections_.at(i);
+}
+
+AttributeMap& MultiTriangleCollection::attr_at(size_t i)
+{
+  return attributes_.at(i);
+}
+const AttributeMap& MultiTriangleCollection::attr_at(size_t i) const
+{
+  return attributes_.at(i);
+}
+
 } // namespace geoflow

--- a/src/geoflow/common.hpp
+++ b/src/geoflow/common.hpp
@@ -138,6 +138,32 @@ public:
   float *get_data_ptr();
 };
 
+// MultiTriangleCollection stores a collection of TriangleCollections along with
+// attributes for each TriangleCollection. The vector of TriangleCollections
+// `trianglecollections_` and the vector of AttributeMaps `attributes_`
+// supposed to have the same length when attributes are present, however this is
+// not enforced. The `attributes_` can be empty.
+class MultiTriangleCollection
+{
+  std::vector<TriangleCollection> trianglecollections_;
+  std::vector<AttributeMap>       attributes_;
+
+public:
+  void push_back(TriangleCollection & trianglecollection);
+  void push_back(AttributeMap & attributemap);
+  std::vector<TriangleCollection>& get_tricollections();
+  const std::vector<TriangleCollection>& get_tricollections() const;
+  std::vector<AttributeMap>& get_attributes();
+  const std::vector<AttributeMap>& get_attributes() const;
+  TriangleCollection& tri_at(size_t i);
+  const TriangleCollection& tri_at(size_t i) const;
+  AttributeMap& attr_at(size_t i);
+  const AttributeMap& attr_at(size_t i) const;
+  size_t tri_size() const;
+  size_t attr_size() const;
+  bool has_attributes();
+};
+
 class SegmentCollection : public GeometryCollection<std::array<arr3f, 2>>
 {
 public:

--- a/src/geoflow/common.hpp
+++ b/src/geoflow/common.hpp
@@ -38,7 +38,9 @@ typedef std::vector<float> vec1f;
 typedef std::vector<size_t> vec1ui;
 typedef std::vector<std::string> vec1s;
 
-typedef std::unordered_map<std::string, std::vector<float>> AttributeMap;
+// Attribute types
+typedef std::variant<bool, int, std:: string, float> variant;
+typedef std::unordered_map<std::string, std::vector<variant>> AttributeMap;
 
 class Box
 {

--- a/src/geoflow/common.hpp
+++ b/src/geoflow/common.hpp
@@ -40,8 +40,8 @@ typedef std::vector<size_t> vec1ui;
 typedef std::vector<std::string> vec1s;
 
 // Attribute types
-typedef std::variant<bool, int, std:: string, float> variant;
-typedef std::unordered_map<std::string, std::vector<variant>> AttributeMap;
+typedef std::variant<bool, int, std:: string, float> attribute_value;
+typedef std::unordered_map<std::string, std::vector<attribute_value>> AttributeMap;
 
 class Box
 {

--- a/src/geoflow/common.hpp
+++ b/src/geoflow/common.hpp
@@ -24,6 +24,7 @@
 #include <typeinfo>
 #include <typeindex>
 #include <string>
+#include <variant>
 
 namespace geoflow
 {

--- a/src/geoflow/common.hpp
+++ b/src/geoflow/common.hpp
@@ -163,6 +163,7 @@ public:
   size_t tri_size() const;
   size_t attr_size() const;
   bool has_attributes();
+  bool has_attributes() const;
 };
 
 class SegmentCollection : public GeometryCollection<std::array<arr3f, 2>>


### PR DESCRIPTION
+ Updates the AttributeMap from storing only floats to a variant type of bool, float, int, string. I looked around a bit in some of the plugins and if I understood well then this change shouldn't require changes in the plugins, but I'm not sure about it.

+ Add a MultiTriangleCollection that stores a collection of TriangleCollections along with
attributes for each TriangleCollection. The vector of TriangleCollections `trianglecollections_` and the vector of AttributeMaps `attributes_` supposed to have the same length when attributes are present, however this is not enforced. The `attributes_` can be empty.  Initially I though to simply make the data members public and be done with it, since both of them are vectors, but then I've seen that for the `Mesh` you also hid the data members. Its more future-proof this way. Since the attribute-type (now AttributeMap) is likely to change in the future.