### PR TITLE
Error handling

### DIFF
--- a/apps/geoflow-app.cpp
+++ b/apps/geoflow-app.cpp
@@ -255,7 +255,7 @@ int main(int argc, const char * argv[]) {
             } catch (const std::exception& e) {
               std::cerr << "Error in parsing global parameters\n";
               std::cerr << e.what();
-              // return 1;
+              throw;
             }
           }
         }
@@ -294,6 +294,7 @@ int main(int argc, const char * argv[]) {
         launch_gui(flowchart, flowchart_path);
         }
         catch (const gfException& e) {
+          std::cerr.clear();
           std::cerr << e.what() << "\n";
           throw;
         }
@@ -302,6 +303,7 @@ int main(int argc, const char * argv[]) {
           if (*run_subcommand) flowchart.run_all();
         }
         catch (const gfException& e) {
+          std::cerr.clear();
           std::cerr << e.what() << "\n";
           throw;
         }

--- a/apps/geoflow-app.cpp
+++ b/apps/geoflow-app.cpp
@@ -275,9 +275,21 @@ int main(int argc, const char * argv[]) {
     // launch gui or just run the flowchart in cli mode
     fs::current_path(flowchart_folder);
     #ifdef GF_BUILD_WITH_GUI
-      launch_gui(flowchart, flowchart_path);
+      try {
+        launch_gui(flowchart, flowchart_path);
+      }
+      catch (const gfException& e) {
+        std::cerr << e.what() << "\n";
+        throw;
+      }
     #else
-      if (*run_subcommand) flowchart.run_all();
+      try {
+        if (*run_subcommand) flowchart.run_all();
+      }
+      catch (const gfException& e) {
+        std::cerr << e.what() << "\n";
+        throw;
+      }
     #endif
 
 

--- a/apps/geoflow-app.cpp
+++ b/apps/geoflow-app.cpp
@@ -244,12 +244,10 @@ int main(int argc, const char * argv[]) {
                   gptr->set(true);
                 else if(concat_values == "false")
                   gptr->set(false);
-                else throw gfException("failed to get boolean from string\n");
+                else throw gfFlowchartError("failed to get boolean from string");
               }
             } catch (const std::exception& e) {
-              std::cout << "Error in parsing global parameters\n";
-              std::cout << e.what();
-              return 1;
+              throw(gfFlowchartError("Error in parsing global parameters"));
             }
           }
         }

--- a/src/geoflow/geoflow.cpp
+++ b/src/geoflow/geoflow.cpp
@@ -149,10 +149,10 @@ std::set<NodeHandle> gfOutputTerminal::get_child_nodes() {
 void gfOutputTerminal::connect(gfInputTerminal& in) {
     //check type compatibility
   if (!is_compatible(in))
-    throw gfNodeInputTypeError("Failed to connect ouput " +get_name()+ " from "+parent_.get_name()+" to input " + in.get_name() + " from " +in.parent_.get_name()+ ". Terminals have incompatible types!");
+    throw gfNodeTerminalError("Failed to connect output " +get_name()+ " from "+parent_.get_name()+" to input " + in.get_name() + " from " +in.parent_.get_name()+ ". Terminals have incompatible types!");
     
   if (detect_loop(*this, in))
-    throw gfNodeInputTypeError("Failed to connect ouput " +get_name()+ " from "+parent_.get_name()+" to input " + in.get_name() + " from " +in.parent_.get_name()+ ". Loop detected!");
+    throw gfNodeTerminalError("Failed to connect output " +get_name()+ " from "+parent_.get_name()+" to input " + in.get_name() + " from " +in.parent_.get_name()+ ". Loop detected!");
 
   in.connect_output(*this);
   connections_.insert(in.get_ptr());
@@ -737,7 +737,7 @@ std::vector<NodeHandle> NodeManager::json_unserialise(std::istream& json_sstream
             if (nodes.count(cval[0]))
               try {
                 if (!nodes[cval[0]]->input_terminals.count(cval[1]))
-                  throw gfNodeInputTypeError("No input terminal '" + cval[1] + "' on node '" + cval[0] + "', failed to connect.");
+                  throw gfNodeTerminalError("No input terminal '" + cval[1] + "' on node '" + cval[0] + "', failed to connect.");
                 nhandle->output_terminals.at(conn_j.key())->connect(*nodes.at(cval[0])->input_terminals[cval[1]]);
               } catch (const std::exception& e) {
                 if(strict) {

--- a/src/geoflow/geoflow.hpp
+++ b/src/geoflow/geoflow.hpp
@@ -57,7 +57,7 @@ namespace geoflow {
   {
   public:
     explicit gfException(const std::string& message):
-      msg_(message)
+      msg_("Error: " + message)
       {}
     virtual const char* what() const throw (){
       return msg_.c_str();
@@ -71,67 +71,31 @@ namespace geoflow {
   class gfFlowchartError: public gfException
   {
   public:
-    explicit gfFlowchartError(const std::string& message)
-      : gfException(message)
-      , msg_(message)
-    {}
-    virtual const char* what() const throw (){
-      return msg_.c_str();
-    }
-
-  protected:
-    std::string msg_;
+    using gfException::gfException;
   };
 
   // Thrown at a broken input (e.g. invalid file paths).
   class gfIOError: public gfException
   {
   public:
-    explicit gfIOError(const std::string& message)
-      : gfException(message)
-      , msg_(message)
-    {}
-    virtual const char* what() const throw (){
-      return msg_.c_str();
-    }
-
-  protected:
-    std::string msg_;
+    using gfException::gfException;
   };
 
   // Thrown when the data on the inputs of a node has the right type but
-  // an inappropriate value (e.g. two input vectors should be of the same
+  // inappropriate data (e.g. two input vectors should be of the same
   // length).
-  class gfNodeInputValueError: public gfException
+  class gfNodeInputDataError: public gfException
   {
   public:
-    explicit gfNodeInputValueError(const std::string& message)
-      : gfException(message)
-      , msg_(message)
-    {}
-    virtual const char* what() const throw (){
-      return msg_.c_str();
-    }
-
-  protected:
-    std::string msg_;
+    using gfException::gfException;
   };
 
   // Thrown when the data on the inputs of a node has an inappropriate type
   // or logic (e.g. a loop).
-  class gfNodeInputTypeError: public gfException
+  class gfNodeTerminalError: public gfException
   {
   public:
-    explicit gfNodeInputTypeError(const std::string& message)
-      : gfException(message)
-      , msg_(message)
-    {}
-    virtual const char* what() const throw (){
-      return msg_.c_str();
-    }
-
-  protected:
-    std::string msg_;
+    using gfException::gfException;
   };
 
   class Node;

--- a/src/geoflow/geoflow.hpp
+++ b/src/geoflow/geoflow.hpp
@@ -50,6 +50,9 @@ namespace geoflow {
     const std::string* get_name_ptr() const { return &name_; };
   };
 
+  // This is the base class for all Geoflow exceptions.
+  // More specific exceptions are derived from this class.
+  // This class is also used when all Geoflow exception need to be caught.
   class gfException: public std::exception
   {
   public:
@@ -62,6 +65,73 @@ namespace geoflow {
 
   protected:
       std::string msg_;
+  };
+
+  // Thrown when there are issues with the flowchart (e.g. it cannot be read).
+  class gfFlowchartError: public gfException
+  {
+  public:
+    explicit gfFlowchartError(const std::string& message)
+      : gfException(message)
+      , msg_(message)
+    {}
+    virtual const char* what() const throw (){
+      return msg_.c_str();
+    }
+
+  protected:
+    std::string msg_;
+  };
+
+  // Thrown at a broken input (e.g. invalid file paths).
+  class gfIOError: public gfException
+  {
+  public:
+    explicit gfIOError(const std::string& message)
+      : gfException(message)
+      , msg_(message)
+    {}
+    virtual const char* what() const throw (){
+      return msg_.c_str();
+    }
+
+  protected:
+    std::string msg_;
+  };
+
+  // Thrown when the data on the inputs of a node has the right type but
+  // an inappropriate value (e.g. two input vectors should be of the same
+  // length).
+  class gfNodeInputValueError: public gfException
+  {
+  public:
+    explicit gfNodeInputValueError(const std::string& message)
+      : gfException(message)
+      , msg_(message)
+    {}
+    virtual const char* what() const throw (){
+      return msg_.c_str();
+    }
+
+  protected:
+    std::string msg_;
+  };
+
+  // Thrown when the data on the inputs of a node has an inappropriate type
+  // or logic (e.g. a loop).
+  class gfNodeInputTypeError: public gfException
+  {
+  public:
+    explicit gfNodeInputTypeError(const std::string& message)
+      : gfException(message)
+      , msg_(message)
+    {}
+    virtual const char* what() const throw (){
+      return msg_.c_str();
+    }
+
+  protected:
+    std::string msg_;
   };
 
   class Node;


### PR DESCRIPTION
Okay, I started a draft, because I'm not sure if this is exactly what you had in mind.
There are two things/questions:

*Subclassing `gfException`*
You mentioned that there will be, or could be different exceptions for the GUI for instance, or other things. I don't know what those will be yet and those are probably best created when the need arise.
In any case, I think we need a catch-all at the app level, and thus an exception base class. This would be the current `gfException`. When we need more specific exceptions, we subclass `gfException` and they will be still caught by the catching `gfException` the app level.

*Print to cout or cerr*
I think that the exceptions should be sent to cerr, because then they can be redirected and recognized easily either in the terminal or by another software that calls geoflow (eg python script).
But I see that you have a different opinion:
https://github.com/geoflow3d/geoflow/blob/dfcc5f511db54d23964311a79473d700981913fa/src/geoflow/geoflow.cpp#L666-L668

https://github.com/geoflow3d/geoflow/blob/dfcc5f511db54d23964311a79473d700981913fa/src/geoflow/geoflow.cpp#L692-L695

For instance, I would have sent both of these to cerr since the errors most likely prohibit the correct execution of the software, and thus the software should stop on its own, or it should send an error message that is easy to catch (eg by being in stderr).

What do you think?
